### PR TITLE
Fix occasional pitch graph crash bug

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,6 @@ dependencies {
     compile 'com.android.support:design:23.1.1'
     compile 'com.android.support:support-v4:23.1.1'
     compile 'com.google.code.gson:gson:2.3'
-    compile 'com.github.PhilJay:MPAndroidChart:v2.1.0'
+    compile 'com.github.PhilJay:MPAndroidChart:v2.2.5'
     compile 'joda-time:joda-time:2.4'
 }

--- a/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/fragments/RecordGraphFragment.java
+++ b/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/fragments/RecordGraphFragment.java
@@ -16,8 +16,8 @@ import com.github.mikephil.charting.data.ChartData;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.LineData;
 import com.github.mikephil.charting.data.LineDataSet;
+import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.listener.OnChartValueSelectedListener;
-import com.github.mikephil.charting.utils.Highlight;
 
 import de.lilithwittmann.voicepitchanalyzer.R;
 import de.lilithwittmann.voicepitchanalyzer.activities.RecordViewActivity;
@@ -118,7 +118,7 @@ public class RecordGraphFragment extends Fragment implements OnChartValueSelecte
         chart.setDoubleTapToZoomEnabled(false);
         chart.setDrawGridBackground(false);
 
-        chart.setHighlightEnabled(true);
+        dataSet.setHighlightEnabled(true);
 
         chart.setHardwareAccelerationEnabled(true);
 //        chart.animateX(3000);

--- a/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/utils/GraphLayout.java
+++ b/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/utils/GraphLayout.java
@@ -29,7 +29,7 @@ public class GraphLayout
         chart.setDoubleTapToZoomEnabled(false);
         chart.setDrawGridBackground(false);
 
-        chart.setHighlightEnabled(true);
+        chart.getData().setHighlightEnabled(true);
 
         chart.setHardwareAccelerationEnabled(true);
         chart.getLegend().setEnabled(false);

--- a/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/utils/GraphValueFormatter.java
+++ b/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/utils/GraphValueFormatter.java
@@ -1,20 +1,21 @@
 package de.lilithwittmann.voicepitchanalyzer.utils;
 
-import com.github.mikephil.charting.utils.ValueFormatter;
+import com.github.mikephil.charting.components.YAxis;
+import com.github.mikephil.charting.formatter.YAxisValueFormatter;
 
 import java.text.DecimalFormat;
 
 /**
  * Created by Yuri on 06/07/15.
  */
-public class GraphValueFormatter implements ValueFormatter {
+public class GraphValueFormatter implements YAxisValueFormatter {
     private DecimalFormat format = new DecimalFormat("###,###,##0.0");
 
     public GraphValueFormatter() {
     }
 
     @Override
-    public String getFormattedValue(float value) {
+    public String getFormattedValue(float value, YAxis yAxis) {
         return String.format("%sHz", format.format(value));
     }
 }


### PR DESCRIPTION
For issue #16. 

Updates MPAndroidChart to v2.2.5 to fix occasional crashing caused by an OOM exception with it in the pitch graph view. Bug with the library is described here: https://github.com/PhilJay/MPAndroidChart/issues/1386 and the bug appears to have been fixed in <v2.2.5.

Tested for 20 minutes on my phone with many many other apps open and was unable to get it to crash like this again.