### PR TITLE
Fix typos in german translation

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -11,13 +11,13 @@
     <string name="average">Gesamtdurchschnitt</string>
     <string name="max_avg">Durchschnittliches Maximum</string>
     <string name="min_avg">Durchschnittliches Minimum</string>
-    <string name="female_range">Weibliche Stimmlange</string>
+    <string name="female_range">Weibliche Stimmlage</string>
     <string name="male_range">Männliche Stimmlage</string>
     <string name="your_range">Deine Stimmlage</string>
     <string name="female">weiblich</string>
     <string name="in_between">im Mittelfeld</string>
     <string name="male">männlich</string>
-    <string name="personal_range">Deine Stimmlange klingt überwiegend</string>
+    <string name="personal_range">Deine Stimmlage klingt überwiegend</string>
     <string name="action_about">Über</string>
     <string name="libraries">Verwendete Libraries:</string>
     <string name="programming">Programmierung</string>


### PR DESCRIPTION
I fixed two typos, I find while using.