### PR TITLE
fix build, remove analytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.0"
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "de.lilithwittmann.voicepitchanalyzer"
         minSdkVersion 15
-        targetSdkVersion 23
+        targetSdkVersion 30
         versionCode 9
         versionName "1.3.0"
     }
@@ -30,10 +29,10 @@ dependencies {
     implementation files('libs/TarsosDSP-Android-2.2.jar')
     //    implementation 'com.baoyz.swipemenulistview:library:1.3.0'
     //    implementation 'com.wdullaer:swipeactionadapter:1.4.4'
-    implementation 'com.android.support:recyclerview-v7:23.1.1'
-    implementation 'com.android.support:appcompat-v7:23.1.1'
-    implementation 'com.android.support:design:23.1.1'
-    implementation 'com.android.support:support-v4:23.1.1'
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
     implementation 'com.google.code.gson:gson:2.3'
     implementation 'com.github.PhilJay:MPAndroidChart:v2.2.5'
     implementation 'joda-time:joda-time:2.4'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,15 +26,15 @@ repositories {
 
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile files('libs/TarsosDSP-Android-2.2.jar')
-    //    compile 'com.baoyz.swipemenulistview:library:1.3.0'
-//    compile 'com.wdullaer:swipeactionadapter:1.4.4'
-    compile 'com.android.support:recyclerview-v7:23.1.1'
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.android.support:design:23.1.1'
-    compile 'com.android.support:support-v4:23.1.1'
-    compile 'com.google.code.gson:gson:2.3'
-    compile 'com.github.PhilJay:MPAndroidChart:v2.2.5'
-    compile 'joda-time:joda-time:2.4'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation files('libs/TarsosDSP-Android-2.2.jar')
+    //    implementation 'com.baoyz.swipemenulistview:library:1.3.0'
+    //    implementation 'com.wdullaer:swipeactionadapter:1.4.4'
+    implementation 'com.android.support:recyclerview-v7:23.1.1'
+    implementation 'com.android.support:appcompat-v7:23.1.1'
+    implementation 'com.android.support:design:23.1.1'
+    implementation 'com.android.support:support-v4:23.1.1'
+    implementation 'com.google.code.gson:gson:2.3'
+    implementation 'com.github.PhilJay:MPAndroidChart:v2.2.5'
+    implementation 'joda-time:joda-time:2.4'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,14 +1,4 @@
-buildscript {
-    repositories {
-        maven { url 'https://maven.fabric.io/public' }
-    }
-
-    dependencies {
-        classpath 'io.fabric.tools:gradle:1.+'
-    }
-}
 apply plugin: 'com.android.application'
-apply plugin: 'io.fabric'
 
 android {
     compileSdkVersion 23
@@ -32,7 +22,6 @@ android {
 repositories {
     mavenCentral()
     maven { url "https://jitpack.io" }
-    maven { url 'https://maven.fabric.io/public' }
 }
 
 
@@ -41,9 +30,6 @@ dependencies {
     compile files('libs/TarsosDSP-Android-2.2.jar')
     //    compile 'com.baoyz.swipemenulistview:library:1.3.0'
 //    compile 'com.wdullaer:swipeactionadapter:1.4.4'
-    compile('com.crashlytics.sdk.android:crashlytics:2.5.2@aar') {
-        transitive = true;
-    }
     compile 'com.android.support:recyclerview-v7:23.1.1'
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:design:23.1.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,10 +48,6 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activities.RecordingListActivity"/>
         </activity>
-
-        <meta-data
-            android:name="io.fabric.ApiKey"
-            android:value="dbcbf34db2f0d3682f537b48c18e40dab98d3187" />
     </application>
 
 </manifest>

--- a/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/activities/AboutActivity.java
+++ b/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/activities/AboutActivity.java
@@ -2,14 +2,14 @@ package de.lilithwittmann.voicepitchanalyzer.activities;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 
 import de.lilithwittmann.voicepitchanalyzer.R;
 
-public class AboutActivity extends ActionBarActivity
+public class AboutActivity extends AppCompatActivity
 {
     private static final String LOG_TAG = AboutActivity.class.getSimpleName();
 

--- a/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/activities/RecordViewActivity.java
+++ b/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/activities/RecordViewActivity.java
@@ -13,7 +13,6 @@ import android.support.v7.app.ActionBarActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 
-import com.crashlytics.android.Crashlytics;
 
 import java.util.List;
 import java.util.Locale;
@@ -25,7 +24,6 @@ import de.lilithwittmann.voicepitchanalyzer.fragments.RecordingOverviewFragment;
 import de.lilithwittmann.voicepitchanalyzer.fragments.RecordingPlayFragment;
 import de.lilithwittmann.voicepitchanalyzer.models.Recording;
 import de.lilithwittmann.voicepitchanalyzer.models.database.RecordingDB;
-import io.fabric.sdk.android.Fabric;
 
 
 public class RecordViewActivity extends ActionBarActivity implements ActionBar.TabListener, RecordGraphFragment.OnFragmentInteractionListener {
@@ -48,7 +46,6 @@ public class RecordViewActivity extends ActionBarActivity implements ActionBar.T
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Fabric.with(this, new Crashlytics());
         setContentView(R.layout.activity_record_view);
         final ActionBar actionBar = getSupportActionBar();
         actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_TABS);

--- a/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/activities/RecordViewActivity.java
+++ b/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/activities/RecordViewActivity.java
@@ -9,7 +9,7 @@ import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -26,7 +26,7 @@ import de.lilithwittmann.voicepitchanalyzer.models.Recording;
 import de.lilithwittmann.voicepitchanalyzer.models.database.RecordingDB;
 
 
-public class RecordViewActivity extends ActionBarActivity implements ActionBar.TabListener, RecordGraphFragment.OnFragmentInteractionListener {
+public class RecordViewActivity extends AppCompatActivity implements ActionBar.TabListener, RecordGraphFragment.OnFragmentInteractionListener {
     private static final String LOG_TAG = RecordViewActivity.class.getSimpleName();
     public static Recording currentRecord;
     /**

--- a/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/activities/RecordingActivity.java
+++ b/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/activities/RecordingActivity.java
@@ -12,7 +12,6 @@ import android.view.View;
 import android.widget.TabHost;
 import android.widget.TextView;
 
-import com.crashlytics.android.Crashlytics;
 import com.github.mikephil.charting.data.Entry;
 
 import java.util.LinkedList;
@@ -24,7 +23,6 @@ import de.lilithwittmann.voicepitchanalyzer.fragments.RecordGraphFragment;
 import de.lilithwittmann.voicepitchanalyzer.fragments.RecordingFragment;
 import de.lilithwittmann.voicepitchanalyzer.models.Recording;
 import de.lilithwittmann.voicepitchanalyzer.utils.PitchCalculator;
-import io.fabric.sdk.android.Fabric;
 
 /***
  * activity containing RecordingFragment with which a new record can be made
@@ -40,7 +38,6 @@ public class RecordingActivity extends ActionBarActivity implements RecordingFra
     protected void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
-        Fabric.with(this, new Crashlytics());
         setContentView(R.layout.activity_recording);
 
         tabHost = (FragmentTabHost)findViewById(R.id.tabhost);

--- a/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/activities/RecordingActivity.java
+++ b/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/activities/RecordingActivity.java
@@ -6,7 +6,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.PersistableBundle;
 import android.support.v4.app.FragmentTabHost;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TabHost;
@@ -28,7 +28,7 @@ import de.lilithwittmann.voicepitchanalyzer.utils.PitchCalculator;
  * activity containing RecordingFragment with which a new record can be made
  */
 
-public class RecordingActivity extends ActionBarActivity implements RecordingFragment.OnFragmentInteractionListener, RecordGraphFragment.OnFragmentInteractionListener
+public class RecordingActivity extends AppCompatActivity implements RecordingFragment.OnFragmentInteractionListener, RecordGraphFragment.OnFragmentInteractionListener
 {
     private static final String LOG_TAG = RecordingActivity.class.getSimpleName();
     private FragmentTabHost tabHost;

--- a/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/activities/RecordingListActivity.java
+++ b/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/activities/RecordingListActivity.java
@@ -9,13 +9,10 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 
-import com.crashlytics.android.Crashlytics;
-
 import de.lilithwittmann.voicepitchanalyzer.R;
 import de.lilithwittmann.voicepitchanalyzer.fragments.RecordingListFragment;
 import de.lilithwittmann.voicepitchanalyzer.fragments.WelcomeFragment;
 import de.lilithwittmann.voicepitchanalyzer.models.Recording;
-import io.fabric.sdk.android.Fabric;
 
 
 public class RecordingListActivity extends AppCompatActivity implements RecordingListFragment.OnFragmentInteractionListener {
@@ -24,7 +21,6 @@ public class RecordingListActivity extends AppCompatActivity implements Recordin
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Fabric.with(this, new Crashlytics());
         setContentView(R.layout.activity_recording_list);
 
         if (savedInstanceState == null) {

--- a/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/fragments/RecordingFragment.java
+++ b/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/fragments/RecordingFragment.java
@@ -18,8 +18,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 
-import com.crashlytics.android.Crashlytics;
-
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
@@ -180,7 +178,6 @@ public class RecordingFragment extends Fragment
     private void setSampleRate()
     {
         this.sampleRate = SampleRateCalculator.getMaxSupportedSampleRate();
-        Crashlytics.log(Log.DEBUG, "usedSampleRate", String.valueOf(this.sampleRate));
         Log.d("sample rate", String.valueOf(this.sampleRate));
     }
 
@@ -264,14 +261,12 @@ public class RecordingFragment extends Fragment
                     // if recording permission was granted, also request permission to modify audio settings
                     this.requestModifyAudioSettingsPermission();
                     Log.i(LOG_TAG, "permission granted");
-                    Crashlytics.log(Log.DEBUG, "recordingPermission", "true");
                 }
 
                 else
                 {
                     // disable "record" button if recording permission was denied
                     Log.i(LOG_TAG, "permission denied");
-                    Crashlytics.log(Log.DEBUG, "recordingPermission", "false");
                     this.disableRecordButton();
 
                     // show explanation why mic permission is needed
@@ -365,12 +360,10 @@ public class RecordingFragment extends Fragment
                             this.dispatcher = AudioDispatcherFactory.fromDefaultMicrophone(testSampleRate, this.bufferRate, 0);
                         } catch (Exception exception_)
                         {
-                            Crashlytics.log(Log.DEBUG, "samplerate !supported", String.valueOf(testSampleRate));
                         }
 
                         if (this.dispatcher != null)
                         {
-                            Crashlytics.log(Log.DEBUG, "support only samplerate", String.valueOf(testSampleRate));
                             break;
                         }
                     }

--- a/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/models/database/RecordingDB.java
+++ b/app/src/main/java/de/lilithwittmann/voicepitchanalyzer/models/database/RecordingDB.java
@@ -7,9 +7,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.provider.BaseColumns;
 
-import com.crashlytics.android.answers.Answers;
-import com.crashlytics.android.answers.CustomEvent;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -57,12 +54,6 @@ public class RecordingDB {
     }
 
     public Recording saveRecording(Recording recording) {
-        //log recordings for statistics
-        Answers.getInstance().logCustom(new CustomEvent("RecordingSaved")
-                .putCustomAttribute("average", recording.getRange().getAvg())
-                .putCustomAttribute("max", recording.getRange().getMax())
-                .putCustomAttribute("min", recording.getRange().getMin()));
-
         // Gets the data repository in write mode
         RecordingDbHelper mDbHelper = new RecordingDbHelper(this.context);
         SQLiteDatabase db = mDbHelper.getWritableDatabase();

--- a/app/src/main/res/layout/listview.xml
+++ b/app/src/main/res/layout/listview.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:layout_width="match_parent"
     android:orientation="vertical">
 <TwoLineListItem

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:4.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -14,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
-#Sat Jan 21 17:32:34 CET 2017
+#Thu Apr 29 13:21:49 PDT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
-#distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip


### PR DESCRIPTION
The app build is broken because Crashlytics has been discontinued and replaced by Firebase for crashes and Google Analytics. Metrics and crashe reports to the fabric.io API stopped being collected on Nov 2020. [Migrating to Firebase](https://firebase.google.com/docs/crashlytics/upgrade-sdk?platform=android) would require creating a Firebase + Google Analytics account, migrating from the legacy Android support libraries to their replacement AndroidX, and migrating to a completely new Google Analytics API for metrics. Since the data isn't being collected as of Nov 2020 anyway, I opted to remove the analytics for now, and it can always be added back later.

I also made a few smaller changes to satisfy lints which which are required to pass while building the release APK.